### PR TITLE
Update drawer.js

### DIFF
--- a/src/drawer.js
+++ b/src/drawer.js
@@ -162,7 +162,7 @@ WaveSurfer.Drawer = {
                 this.recenterOnPosition(newPos);
             }
 
-            this.updateProgress(progress);
+            this.updateProgress(progress, true);
         }
     },
 


### PR DESCRIPTION
Corrects the behaviour of the cursor (centered in the waveform container) when setPlaybackRate=>2.5