### PR TITLE
Added getPlaybackRate() method.

### DIFF
--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -86,6 +86,16 @@ WaveSurfer.util.extend(WaveSurfer.MediaElement, {
         this.playbackRate = value || 1;
         this.media.playbackRate = this.playbackRate;
     },
+    
+    /**
+     * Get the audio source playback rate.
+     */
+    getPlaybackRate: function () {
+    	if (this.media.playbackRate == null) {
+    		this.media.playbackRate = 1;
+    	}
+        return this.media.playbackRate;
+    },
 
     seekTo: function (start) {
         if (start != null) {

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -338,6 +338,16 @@ WaveSurfer.WebAudio = {
             this.playbackRate = value;
             this.play();
         }
+    },
+    
+    /**
+     * Get the audio source playback rate.
+     */
+    getPlaybackRate: function () {
+    	if (this.playbackRate == null) {
+    		this.setPlaybackRate(1);
+    	}
+        return this.playbackRate;
     }
 };
 


### PR DESCRIPTION
Adds getPlaybackRate() method. Unable to use this.setPlaybackRate(1) in this.getPlaybackRate(). 

An "Uncaught TypeError: Cannot read property '0' of undefined" error would occur at isPaused() method.